### PR TITLE
Initial GUI cleanup

### DIFF
--- a/src/gui/__init__.py
+++ b/src/gui/__init__.py
@@ -80,7 +80,7 @@ class MainWindow(sc.SizedFrame):
 
         self.add_button = create_button(files_list_buttons_panel, _('&Add'), self.onAdd)
         self.remove_file_button = create_button(files_list_buttons_panel, _('&Remove file'), self.onRemoveFile)
-        self.remove_file_button.Hide()
+        self.remove_file_button.Disable()
 
         self.main_buttons_panel = sc.SizedPanel(main_panel)
         self.main_buttons_panel.SetSizerType('horizontal')
@@ -146,6 +146,7 @@ class MainWindow(sc.SizedFrame):
         return help_menu
 
     def reset(self):
+        self.remove_file_button.Disable()
         self.convert_button.Disable()
         self.remove_drm_button.Disable()
         self.main_buttons_panel.Disable()
@@ -163,7 +164,7 @@ class MainWindow(sc.SizedFrame):
 
     def onFilesListSelectionChange(self, event):
         if event.IsSelection():
-            self.remove_file_button.Show()
+            self.remove_file_button.Enable()
         else:
             event.Skip()
 

--- a/src/gui/__init__.py
+++ b/src/gui/__init__.py
@@ -88,16 +88,24 @@ class MainWindow(sc.SizedFrame):
 
         convert_button = create_button(main_buttons_panel, _('&Convert'), self.onConvert, wx.ID_CONVERT)
         remove_drm_button = create_button(main_buttons_panel, _('Remove &DRM'), self.onRemoveDRM, wx.ID_CONVERT)
-        options_button = create_button(main_buttons_panel, _('O&ptions'), self.onOptions, id=wx.ID_PREFERENCES)
-        exit_button = create_button(main_buttons_panel, _('E&xit'), self.onExit, id=wx.ID_EXIT)
 
     def create_menus(self):
+        file_menu = self.create_file_menu()
         tools_menu = self.create_tools_menu()
         help_menu = self.create_help_menu()
         menu_bar = wx.MenuBar()
+        menu_bar.Append(file_menu, _('&File'))
         menu_bar.Append(tools_menu, _('&Tools'))
         menu_bar.Append(help_menu, _('&Help'))
         self.SetMenuBar(menu_bar)
+
+    def create_file_menu(self):
+        file_menu = wx.Menu()
+        options = file_menu.Append(wx.ID_PREFERENCES, _('&Options...\tCtrl+P'))
+        self.Bind(wx.EVT_MENU, self.onOptions, options)
+        exit = file_menu.Append(wx.ID_EXIT, _('&Exit\tAlt+F4'))
+        self.Bind(wx.EVT_MENU, self.onExit, exit)
+        return file_menu
 
     def create_tools_menu(self):
         tools_menu = wx.Menu()

--- a/src/gui/__init__.py
+++ b/src/gui/__init__.py
@@ -67,7 +67,7 @@ class MainWindow(sc.SizedFrame):
         main_panel = self.GetContentsPane()
         main_panel.SetSizerType('vertical')
 
-        files_list_label = wx.StaticText(main_panel, label=_('&Files'))
+        files_list_label = wx.StaticText(main_panel, label=_('Files'))
         self.files_list = wx.ListBox(main_panel, style=wx.LB_NEEDED_SB)
         self.files_list.SetSizerProps(expand=True, proportion=1)
         self.files_list.Bind(wx.EVT_CHAR, self.onFilesListKeyPressed)
@@ -84,7 +84,7 @@ class MainWindow(sc.SizedFrame):
         main_buttons_panel = sc.SizedPanel(main_panel)
         main_buttons_panel.SetSizerType('horizontal')
 
-        self.output_formats = get_output_format_choices(main_buttons_panel, _('Output &format'))
+        self.output_formats = get_output_format_choices(main_buttons_panel, _('O&utput format'))
 
         convert_button = create_button(main_buttons_panel, _('&Convert'), self.onConvert, wx.ID_CONVERT)
         remove_drm_button = create_button(main_buttons_panel, _('Remove &DRM'), self.onRemoveDRM, wx.ID_CONVERT)

--- a/src/gui/__init__.py
+++ b/src/gui/__init__.py
@@ -187,7 +187,7 @@ class MainWindow(sc.SizedFrame):
                 self.output_formats.Enable()
 
     def onAddDirectory(self, event):
-        folder_dialog = wx.DirDialog(self, message=_('Please select the folder to be added'), defaultPath=application.config['working_directory'], style=wx.DD_DEFAULT_STYLE|wx.DD_DIR_MUST_EXIST)
+        folder_dialog = wx.DirDialog(self, message=_('Please select the directory to be added'), defaultPath=application.config['working_directory'], style=wx.DD_DEFAULT_STYLE|wx.DD_DIR_MUST_EXIST)
         result = folder_dialog.ShowModal()
 
         if result == wx.ID_OK:

--- a/src/gui/__init__.py
+++ b/src/gui/__init__.py
@@ -77,7 +77,7 @@ class MainWindow(sc.SizedFrame):
         files_list_buttons_panel.SetSizerType('horizontal')
 
         add_files_button = create_button(files_list_buttons_panel, _('Add f&iles...'), self.onAddFiles)
-        add_folder_button = create_button(files_list_buttons_panel, _('Add f&older...'), self.onAddFolder)
+        add_folder_button = create_button(files_list_buttons_panel, _('Add f&older...'), self.onAddDirectory)
         self.remove_file_button = create_button(files_list_buttons_panel, _('&Remove file'), self.onRemoveFile)
         self.remove_file_button.Hide()
 
@@ -101,6 +101,11 @@ class MainWindow(sc.SizedFrame):
 
     def create_file_menu(self):
         file_menu = wx.Menu()
+        add_files = file_menu.Append(wx.ID_OPEN, _('Add f&iles...\tCtrl+O'))
+        self.Bind(wx.EVT_MENU, self.onAddFiles, add_files)
+        add_directory = file_menu.Append(wx.NewId(), _('Add &directory...\tCtrl+D'))
+        self.Bind(wx.EVT_MENU, self.onAddDirectory, add_directory)
+        file_menu.AppendSeparator()
         options = file_menu.Append(wx.ID_PREFERENCES, _('&Options...\tCtrl+P'))
         self.Bind(wx.EVT_MENU, self.onOptions, options)
         exit = file_menu.Append(wx.ID_EXIT, _('&Exit\tAlt+F4'))
@@ -158,7 +163,7 @@ class MainWindow(sc.SizedFrame):
             application.config['working_directory'] = os.path.split(file_dialog.GetPath())[0]
             self.files_list.SetFocus()
 
-    def onAddFolder(self, event):
+    def onAddDirectory(self, event):
         folder_dialog = wx.DirDialog(self, message=_('Please select the folder to be added'), defaultPath=application.config['working_directory'], style=wx.DD_DEFAULT_STYLE|wx.DD_DIR_MUST_EXIST)
         result = folder_dialog.ShowModal()
 

--- a/src/gui/__init__.py
+++ b/src/gui/__init__.py
@@ -1,5 +1,5 @@
 # Codex
-# Copyright (C) 2015 James Scholes
+# Copyright (C) 2020 James Scholes
 # This program is free software, licensed under the terms of the GNU General Public License (version 3 or later).
 # See the file LICENSE.txt for more details.
 import os.path
@@ -20,13 +20,13 @@ from . import conversion_pipeline
 from . import dialogs
 from .utils import create_button, create_labelled_field, get_output_format_choices
 
+
 class MainWindow(sc.SizedFrame):
     def __init__(self, *args, **kwargs):
         super(MainWindow, self).__init__(None, -1, _(application.title), size=(800, 600), style=wx.DEFAULT_FRAME_STYLE, *args, **kwargs)
         self.Centre()
         self.setup_layout()
-        self.setup_tools_menu()
-        self.setup_help_menu()
+        self.create_menus()
 
     def open_readme(self):
         if not application.is_frozen:
@@ -91,27 +91,35 @@ class MainWindow(sc.SizedFrame):
         options_button = create_button(main_buttons_panel, _('O&ptions'), self.onOptions, id=wx.ID_PREFERENCES)
         if not application.is_frozen:
             calibre_environment_button = create_button(main_buttons_panel, '&Launch Calibre environment', self.onCalibreEnvironment)
-        self.tools_button = create_button(main_buttons_panel, _('&Tools'), self.onTools)
-        self.help_button = create_button(main_buttons_panel, _('&Help'), self.onHelp, wx.ID_HELP)
         exit_button = create_button(main_buttons_panel, _('E&xit'), self.onExit, id=wx.ID_EXIT)
 
-    def setup_tools_menu(self):
-        self.tools_menu = wx.Menu()
-        find_book_from_url = self.tools_menu.Append(wx.NewId(), _('&Find Kindle file from Amazon URL'))
-        self.Bind(wx.EVT_MENU, self.onFindBookFromUrl, find_book_from_url)
-        browse_kindle_books = self.tools_menu.Append(wx.NewId(), _('&Browse downloaded Kindle books'))
-        self.Bind(wx.EVT_MENU, self.onBrowseKindleBooks, browse_kindle_books)
+    def create_menus(self):
+        tools_menu = self.create_tools_menu()
+        help_menu = self.create_help_menu()
+        menu_bar = wx.MenuBar()
+        menu_bar.Append(tools_menu, _('&Tools'))
+        menu_bar.Append(help_menu, _('&Help'))
+        self.SetMenuBar(menu_bar)
 
-    def setup_help_menu(self):
-        self.help_menu = wx.Menu()
-        help_menu_documentation = self.help_menu.Append(wx.NewId(), _('&Documentation'))
+    def create_tools_menu(self):
+        tools_menu = wx.Menu()
+        find_book_from_url = tools_menu.Append(wx.NewId(), _('&Find Kindle file from Amazon URL...'))
+        self.Bind(wx.EVT_MENU, self.onFindBookFromUrl, find_book_from_url)
+        browse_kindle_books = tools_menu.Append(wx.NewId(), _('&Browse downloaded Kindle books...'))
+        self.Bind(wx.EVT_MENU, self.onBrowseKindleBooks, browse_kindle_books)
+        return tools_menu
+
+    def create_help_menu(self):
+        help_menu = wx.Menu()
+        help_menu_documentation = help_menu.Append(wx.NewId(), _('&Documentation'))
         self.Bind(wx.EVT_MENU, self.onDocumentation, help_menu_documentation)
-        help_menu_home_page = self.help_menu.Append(wx.NewId(), _('&Codex home page'))
+        help_menu_home_page = help_menu.Append(wx.NewId(), _('&Codex home page'))
         self.Bind(wx.EVT_MENU, self.onHomePage, help_menu_home_page)
-        help_menu_open_config_directory = self.help_menu.Append(wx.NewId(), _('&Open Codex configuration directory'))
+        help_menu_open_config_directory = help_menu.Append(wx.NewId(), _('&Open Codex configuration directory'))
         self.Bind(wx.EVT_MENU, self.onOpenConfigDirectory, help_menu_open_config_directory)
-        help_menu_about = self.help_menu.Append(wx.ID_ABOUT, _('&About'))
+        help_menu_about = help_menu.Append(wx.ID_ABOUT, _('&About...'))
         self.Bind(wx.EVT_MENU, self.onAbout, help_menu_about)
+        return help_menu
 
     def reset(self):
         self.files_list.Clear()
@@ -172,12 +180,6 @@ class MainWindow(sc.SizedFrame):
     def onCalibreEnvironment(self, event):
         calibre.setup()
         subprocess.Popen(['cmd.exe'], cwd=calibre.calibre_path, creationflags=subprocess.CREATE_NEW_CONSOLE)
-
-    def onTools(self, event):
-        self.PopupMenu(self.tools_menu, self.help_button.GetScreenPosition())
-
-    def onHelp(self, event):
-        self.PopupMenu(self.help_menu, self.help_button.GetScreenPosition())
 
     def onFindBookFromUrl(self, event):
         find_dialog = dialogs.FindBookFromURLDialog(self)

--- a/src/gui/__init__.py
+++ b/src/gui/__init__.py
@@ -89,8 +89,6 @@ class MainWindow(sc.SizedFrame):
         convert_button = create_button(main_buttons_panel, _('&Convert'), self.onConvert, wx.ID_CONVERT)
         remove_drm_button = create_button(main_buttons_panel, _('Remove &DRM'), self.onRemoveDRM, wx.ID_CONVERT)
         options_button = create_button(main_buttons_panel, _('O&ptions'), self.onOptions, id=wx.ID_PREFERENCES)
-        if not application.is_frozen:
-            calibre_environment_button = create_button(main_buttons_panel, '&Launch Calibre environment', self.onCalibreEnvironment)
         exit_button = create_button(main_buttons_panel, _('E&xit'), self.onExit, id=wx.ID_EXIT)
 
     def create_menus(self):
@@ -107,6 +105,9 @@ class MainWindow(sc.SizedFrame):
         self.Bind(wx.EVT_MENU, self.onFindBookFromUrl, find_book_from_url)
         browse_kindle_books = tools_menu.Append(wx.NewId(), _('&Browse downloaded Kindle books...'))
         self.Bind(wx.EVT_MENU, self.onBrowseKindleBooks, browse_kindle_books)
+        if not application.is_frozen:
+            calibre_environment = tools_menu.Append(wx.NewId(), _('&Launch Calibre environment'))
+            self.Bind(wx.EVT_MENU, self.onCalibreEnvironment, calibre_environment)
         return tools_menu
 
     def create_help_menu(self):

--- a/src/gui/__init__.py
+++ b/src/gui/__init__.py
@@ -82,14 +82,16 @@ class MainWindow(sc.SizedFrame):
         self.remove_file_button = create_button(files_list_buttons_panel, _('&Remove file'), self.onRemoveFile)
         self.remove_file_button.Hide()
 
-        main_buttons_panel = sc.SizedPanel(main_panel)
-        main_buttons_panel.SetSizerType('horizontal')
+        self.main_buttons_panel = sc.SizedPanel(main_panel)
+        self.main_buttons_panel.SetSizerType('horizontal')
+        self.main_buttons_panel.Disable()
 
-        self.output_formats = get_output_format_choices(main_buttons_panel, _('O&utput format'))
+        self.output_formats = get_output_format_choices(self.main_buttons_panel, _('O&utput format'))
+        self.output_formats.Disable()
 
-        self.convert_button = create_button(main_buttons_panel, _('&Convert'), self.onConvert, wx.ID_CONVERT)
+        self.convert_button = create_button(self.main_buttons_panel, _('&Convert'), self.onConvert, wx.ID_CONVERT)
         self.convert_button.Disable()
-        self.remove_drm_button = create_button(main_buttons_panel, _('Remove &DRM'), self.onRemoveDRM, wx.ID_CONVERT)
+        self.remove_drm_button = create_button(self.main_buttons_panel, _('Remove &DRM'), self.onRemoveDRM, wx.ID_CONVERT)
         self.remove_drm_button.Disable()
 
     def create_menus(self):
@@ -146,6 +148,8 @@ class MainWindow(sc.SizedFrame):
     def reset(self):
         self.convert_button.Disable()
         self.remove_drm_button.Disable()
+        self.main_buttons_panel.Disable()
+        self.output_formats.Disable()
         self.files_list.Clear()
         self.files_list.SetFocus()
 
@@ -178,7 +182,8 @@ class MainWindow(sc.SizedFrame):
             if self.files_list.GetCount() != 0:
                 self.convert_button.Enable()
                 self.remove_drm_button.Enable()
-
+                self.main_buttons_panel.Enable()
+                self.output_formats.Enable()
 
     def onAddDirectory(self, event):
         folder_dialog = wx.DirDialog(self, message=_('Please select the folder to be added'), defaultPath=application.config['working_directory'], style=wx.DD_DEFAULT_STYLE|wx.DD_DIR_MUST_EXIST)

--- a/src/gui/__init__.py
+++ b/src/gui/__init__.py
@@ -53,6 +53,8 @@ class MainWindow(sc.SizedFrame):
                     else:
                         next_item_index = selected_item
                     self.files_list.SetSelection(next_item_index)
+                else:
+                    self.reset()
             except wx.PyAssertionError:
                 pass
 
@@ -85,8 +87,10 @@ class MainWindow(sc.SizedFrame):
 
         self.output_formats = get_output_format_choices(main_buttons_panel, _('O&utput format'))
 
-        convert_button = create_button(main_buttons_panel, _('&Convert'), self.onConvert, wx.ID_CONVERT)
-        remove_drm_button = create_button(main_buttons_panel, _('Remove &DRM'), self.onRemoveDRM, wx.ID_CONVERT)
+        self.convert_button = create_button(main_buttons_panel, _('&Convert'), self.onConvert, wx.ID_CONVERT)
+        self.convert_button.Disable()
+        self.remove_drm_button = create_button(main_buttons_panel, _('Remove &DRM'), self.onRemoveDRM, wx.ID_CONVERT)
+        self.remove_drm_button.Disable()
 
     def create_menus(self):
         file_menu = self.create_file_menu()
@@ -140,6 +144,8 @@ class MainWindow(sc.SizedFrame):
         return help_menu
 
     def reset(self):
+        self.convert_button.Disable()
+        self.remove_drm_button.Disable()
         self.files_list.Clear()
         self.files_list.SetFocus()
 
@@ -169,6 +175,10 @@ class MainWindow(sc.SizedFrame):
             conversion_pipeline.add_paths(selected_paths, parent=self)
             application.config['working_directory'] = os.path.split(file_dialog.GetPath())[0]
             self.files_list.SetFocus()
+            if self.files_list.GetCount() != 0:
+                self.convert_button.Enable()
+                self.remove_drm_button.Enable()
+
 
     def onAddDirectory(self, event):
         folder_dialog = wx.DirDialog(self, message=_('Please select the folder to be added'), defaultPath=application.config['working_directory'], style=wx.DD_DEFAULT_STYLE|wx.DD_DIR_MUST_EXIST)

--- a/src/gui/__init__.py
+++ b/src/gui/__init__.py
@@ -76,8 +76,7 @@ class MainWindow(sc.SizedFrame):
         files_list_buttons_panel = sc.SizedPanel(main_panel)
         files_list_buttons_panel.SetSizerType('horizontal')
 
-        add_files_button = create_button(files_list_buttons_panel, _('Add f&iles...'), self.onAddFiles)
-        add_folder_button = create_button(files_list_buttons_panel, _('Add f&older...'), self.onAddDirectory)
+        self.add_button = create_button(files_list_buttons_panel, _('&Add'), self.onAdd)
         self.remove_file_button = create_button(files_list_buttons_panel, _('&Remove file'), self.onRemoveFile)
         self.remove_file_button.Hide()
 
@@ -98,6 +97,11 @@ class MainWindow(sc.SizedFrame):
         menu_bar.Append(tools_menu, _('&Tools'))
         menu_bar.Append(help_menu, _('&Help'))
         self.SetMenuBar(menu_bar)
+        self.add_menu = wx.Menu()
+        add_files = self.add_menu.Append(wx.ID_OPEN, _('Add f&iles...\tCtrl+O'))
+        self.Bind(wx.EVT_MENU, self.onAddFiles, add_files)
+        add_directory = self.add_menu.Append(wx.NewId(), _('Add &directory...\tCtrl+D'))
+        self.Bind(wx.EVT_MENU, self.onAddDirectory, add_directory)
 
     def create_file_menu(self):
         file_menu = wx.Menu()
@@ -152,6 +156,9 @@ class MainWindow(sc.SizedFrame):
             self.remove_file_button.Show()
         else:
             event.Skip()
+
+    def onAdd(self, event):
+        self.PopupMenu(self.add_menu, self.add_button.GetScreenPosition())
 
     def onAddFiles(self, event):
         file_dialog = wx.FileDialog(self, message=_('Please select the file(s) to be added'), defaultDir=application.config['working_directory'], wildcard=_('All supported files|{0}|All files|{1}').format(conversion.input_wildcards, '*.*'), style=wx.FD_OPEN|wx.FD_FILE_MUST_EXIST|wx.FD_MULTIPLE)

--- a/src/gui/dialogs.py
+++ b/src/gui/dialogs.py
@@ -1,5 +1,5 @@
 # Codex
-# Copyright (C) 2015 James Scholes
+# Copyright (C) 2020 James Scholes
 # This program is free software, licensed under the terms of the GNU General Public License (version 3 or later).
 # See the file LICENSE.txt for more details.
 import os
@@ -158,7 +158,7 @@ class ConversionCompleteDialog(BaseDialog):
             self.converted_files.SetSelection(0)
             self.open_file_button = create_button(self.panel, _('&Open file'), self.onOpenFile)
             self.open_file_button.SetDefault()
-            self.open_folder_button = create_button(self.panel, _('Open fol&der'), self.onOpenFolder)
+            self.open_directory_button = create_button(self.panel, _('Open &directory'), self.onOpenDirectory)
 
         if len(conversion.failed_conversions) > 0:
             failed_conversions_label = wx.StaticText(self.panel, label=_('&Errors'))
@@ -191,7 +191,7 @@ class ConversionCompleteDialog(BaseDialog):
         except wx.PyAssertionError:
             wx.MessageBox(_('No file selected.'), _('Error'), wx.ICON_ERROR, parent=self)
 
-    def onOpenFolder(self, event):
+    def onOpenDirectory(self, event):
         try:
             book = self.converted_files.GetClientData(self.converted_files.GetSelections()[0])
             os.startfile(os.path.dirname(book.output_path))
@@ -264,13 +264,13 @@ class OptionsDialog(BaseDialog):
                 os.makedirs(output_directory)
                 should_save = True
         elif not os.path.isdir(output_directory):
-            wx.MessageBox(_('The output directory you\'ve chosen is not a folder!'), _('Error'), wx.ICON_ERROR, parent=self)
+            wx.MessageBox(_('The output directory you\'ve chosen doesn\'t actually seem to be a directory.'), _('Error'), wx.ICON_ERROR, parent=self)
 
         kindle_content_directory = os.path.expandvars(self.kindle_content_directory.GetValue())
         if not os.path.exists(kindle_content_directory):
             wx.MessageBox(_('The Kindle content directory you\'ve chosen doesn\'t exist.'), _('Warning'), wx.ICON_INFORMATION, parent=self)
         elif not os.path.isdir(kindle_content_directory):
-            wx.MessageBox(_('The Kindle content directory you\'ve chosen is not a folder.'), _('Warning'), wx.ICON_INFORMATION, parent=self)
+            wx.MessageBox(_('The Kindle content directory you\'ve chosen doesn\'t actually seem to be a directory.'), _('Warning'), wx.ICON_INFORMATION, parent=self)
 
         if should_save:
             application.config['output_directory'] = output_directory


### PR DESCRIPTION
Closes #6 by making several updates to the GUI.  Specifically:

- Exchange Tools and Help menu buttons in main window for an actual menu bar
- Move option to launch calibre CLI environment into new Tools menu
- Create File menu and move Options and Exit into it
- Remove Alt+F accel from files list, and change accel for output formats dropdown to Alt+U, so that the File menu can actually be opened
- Place options in File menu to add files and directories for conversion
- Replace two add buttons for adding files or folders next to Files list with single button to pop up a context menu
- Disable Convert and Remove DRM buttons when Files list is empty
- Also disable the output format dropdown when the files list is empty (along with its parent panel)
- Disable the button to remove a file rather than hiding it, and ensure that this happens at the right time
- Change use of word 'folder' to 'directory' in various places throughout the GUI for consistency